### PR TITLE
pre-release:@react-native-ohos/react-native-textinput-maxlength-fixed@0.1.3-rc.1

### DIFF
--- a/harmony/textinput_maxlength_fixed/BuildProfile.ets
+++ b/harmony/textinput_maxlength_fixed/BuildProfile.ets
@@ -1,7 +1,7 @@
 /**
  * Use these variables when you tailor your ArkTS code. They must be of the const type.
  */
-export const HAR_VERSION = '0.1.2';
+export const HAR_VERSION = '0.1.3-rc.1';
 export const BUILD_MODE_NAME = 'debug';
 export const DEBUG = true;
 export const TARGET_NAME = 'default';

--- a/harmony/textinput_maxlength_fixed/oh-package.json5
+++ b/harmony/textinput_maxlength_fixed/oh-package.json5
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-ohos/react-native-textinput-maxlength-fixed",
-  "version": "0.1.2",
+  "version": "0.1.3-rc.1",
   "description": "React Native wrapper for HarmonyOS textinput",
   "main": "index.ets",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-ohos/react-native-textinput-maxlength-fixed",
-  "version": "0.1.2",
+  "version": "0.1.3-rc.1",
   "description": "fix TextInput's maxLength bug when  using a non-English input method.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
pre-release:@react-native-ohos/react-native-textinput-maxlength-fixed@0.1.3-rc.1
https://github.com/react-native-oh-library/react-native-textinput-maxlength-fixed/issues/10