### PR TITLE
fix: 修改CMakeList.txt文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/harmony/textinput_maxlength_fixed/src/main/cpp/CMakeLists.txt
+++ b/harmony/textinput_maxlength_fixed/src/main/cpp/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-set(rnoh_textinput_maxlength_fixed_dir "${CMAKE_CURRENT_SOURCE_DIR}/generated")
-file(GLOB_RECURSE rnoh_textinput_maxlength_fixed_SRC "${rnoh_textinput_maxlength_fixed_dir}/**/*.cpp")
+set(rnoh_textinput_maxlength_fixed_generated_dir "${CMAKE_CURRENT_SOURCE_DIR}/generated")
+file(GLOB_RECURSE rnoh_textinput_maxlength_fixed_generated_SRC "${rnoh_textinput_maxlength_fixed_generated_dir}/**/*.cpp")
 file(GLOB rnoh_textinput_maxlength_fixed_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(rnoh_textinput_maxlength_fixed SHARED ${rnoh_textinput_maxlength_fixed_SRC} ${rnoh_textinput_maxlength_fixed_SRC})
-target_include_directories(rnoh_textinput_maxlength_fixed PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${rnoh_textinput_maxlength_fixed_dir} ${CMAKE_CURRENT_SOURCE_DIR}/generated/RNOH/generated)
+add_library(rnoh_textinput_maxlength_fixed SHARED ${rnoh_textinput_maxlength_fixed_SRC} ${rnoh_textinput_maxlength_fixed_generated_SRC})
+target_include_directories(rnoh_textinput_maxlength_fixed PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${rnoh_textinput_maxlength_fixed_generated_dir} ${CMAKE_CURRENT_SOURCE_DIR}/generated/RNOH/generated)
 target_link_libraries(rnoh_textinput_maxlength_fixed PUBLIC rnoh)


### PR DESCRIPTION
fix: 修改CMakeList.txt文件
修改命名，解决add_library时路径因命名重复被覆盖从而找不到的问题